### PR TITLE
Update orb.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,6 @@ workflows:
     jobs:
       - orb-tools/publish:
           orb-path: src/orb.yml
-          orb-ref: brandnewbox/drydock@1.4.8
+          orb-ref: brandnewbox/drydock@1.4.9
           publish-token-variable: "$CIRCLECI_DEV_API_TOKEN"
           validate: true

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -13,7 +13,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        drydock: brandnewbox/drydock@1.4.8
+        drydock: brandnewbox/drydock@1.4.9
       workflows:
         devops_flow:
           jobs:

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -272,6 +272,7 @@ jobs:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
+          version: 19.03.13
       - checkout
       - unless:
           condition:


### PR DESCRIPTION
Our update to the Ruby 2.7 pulled along some dependency updates like nodejs. There seems to be some sort of bad interaction between the default docker executor and the newer versions of nodejs https://discuss.circleci.com/t/docker-build-fails-with-nonsensical-eperm-operation-not-permitted-copyfile/37364/32.

This will make the orb run the s2i build and push job using the latest docker that CircleCI supports. This seemed to fix the issue for Jace, [commit](https://github.com/brandnewbox/jaces-cookbook-generator/commit/45da6696b17a072f8e9fb86958ca9bfadac7e3c7) (that build still failed, but it failed past the point that we were getting before the docker change)