### PR TITLE
Switching to CircleCI base image

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -173,7 +173,7 @@ jobs:
       Use the application's custom dockerfile to build an image to a given target and then
       push to a private registry.
     docker:
-      - image: docker:17.09.0-ce
+      - image: cimg/base:2021.04
     parameters:
       dockerfile-path:
         description: Path to the directory containing a custom Dockerfile that should be used to build this project instead of just pulling the base image


### PR DESCRIPTION
We had hardcoded to use a docker 17 image here. This was breaking my recent errbit builds because it didn't have access to the buildkit features. What's weird is we actually went through the process of doing `setup_remote_docker` in the orb, but apparently that's not enough to get the docker version "all of the way upgraded".

So this will modernize us into CircleCI's base image, which has a more recent version of Docker.