### PR TITLE
Supporting real asset caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ workflows:
               ignore: master
       - orb-tools/publish:
           orb-path: src/orb.yml
-          orb-ref: brandnewbox/drydock@2.1.1
+          orb-ref: brandnewbox/drydock@2.2.0
           publish-token-variable: CIRCLECI_DEV_API_TOKEN
           validate: true
           filters:

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -13,7 +13,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        drydock: brandnewbox/drydock@2.0.4
+        drydock: brandnewbox/drydock@2.2.0
       parameters:
         registry:
           type: string

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -220,14 +220,16 @@ jobs:
             - restore_cache:
                 name: Restore Compiled Assets
                 keys:
-                  - v1-asset-cache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+                  - v1-asset-cache-assets-{{ .Branch }}
+                  - v1-asset-cache-assets
       - when:
           condition: << parameters.cache-packs >>
           steps:
             - restore_cache:
                 name: Restore Compiled Packs
                 keys:
-                  - v1-pack-cache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+                  - v1-pack-cache-packs-{{ .Branch }}
+                  - v1-pack-cache-packs
       - run:
           name: Build the builder image
           command: |
@@ -249,7 +251,7 @@ jobs:
                 name: Save Compiled Assets
                 paths:
                   - public/assets
-                key: v1-asset-cache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+                key: v1-asset-cache-{{ .Branch }}-{{ .Revision }}
       - when:
           condition: << parameters.cache-packs >>
           steps:
@@ -263,7 +265,7 @@ jobs:
                 name: Save Compiled Packs
                 paths:
                   - public/packs
-                key: v1-pack-cache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+                key: v1-pack-cache-{{ .Branch }}-{{ .Revision }}
       - run:
           name: Log into private registry
           command: |

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -220,16 +220,16 @@ jobs:
             - restore_cache:
                 name: Restore Compiled Assets
                 keys:
-                  - v1-asset-cache-assets-{{ .Branch }}
-                  - v1-asset-cache-assets
+                  - v1-asset-cache-{{ .Branch }}
+                  - v1-asset-cache
       - when:
           condition: << parameters.cache-packs >>
           steps:
             - restore_cache:
                 name: Restore Compiled Packs
                 keys:
-                  - v1-pack-cache-packs-{{ .Branch }}
-                  - v1-pack-cache-packs
+                  - v1-pack-cache-{{ .Branch }}
+                  - v1-pack-cache
       - run:
           name: Build the builder image
           command: |


### PR DESCRIPTION
Discovered during https://github.com/brandnewbox/devops/issues/153

We were including the revision in our cache lookup so we were never able to actually cache our assets because every commit was looking for a new cache key.