### PR TITLE
Update base images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ workflows:
               ignore: master
       - orb-tools/publish:
           orb-path: src/orb.yml
-          orb-ref: brandnewbox/drydock@2.2.0
+          orb-ref: brandnewbox/drydock@2.2.1
           publish-token-variable: CIRCLECI_DEV_API_TOKEN
           validate: true
           filters:

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -13,7 +13,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        drydock: brandnewbox/drydock@2.2.0
+        drydock: brandnewbox/drydock@2.2.1
       parameters:
         registry:
           type: string
@@ -115,7 +115,7 @@ examples:
               environment:
                 RAILS_ENV: test
                 DATABASE_URL: postgres://circleci:password@localhost:5432/my_database
-            - image: cimg/postgres:14.4
+            - image: cimg/postgres:16.4
               environment:
                 POSTGRES_USER: circleci
                 POSTGRES_PASSWORD: password
@@ -173,7 +173,7 @@ jobs:
       Use the application's custom dockerfile to build an image to a given target and then
       push to a private registry.
     docker:
-      - image: cimg/base:2021.04
+      - image: cimg/base:current
     parameters:
       dockerfile-path:
         description: Path to the directory containing a custom Dockerfile that should be used to build this project instead of just pulling the base image
@@ -343,7 +343,7 @@ jobs:
   
   run-danger:
     docker:
-      - image: cimg/ruby:2.7
+      - image: cimg/ruby:3.3
     steps:
       - checkout
       - run:


### PR DESCRIPTION
CircleCI is phasing out our `2021` base image, and we don't generally rely on the base image, so we're going to tag it to something that will stay up to date.

Also updating the Ruby version used for Danger