### PR TITLE
Fix recursive nesting bug in asset/pack cache extraction

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ workflows:
               ignore: master
       - orb-tools/publish:
           orb-path: src/orb.yml
-          orb-ref: brandnewbox/drydock@2.2.5
+          orb-ref: brandnewbox/drydock@2.2.6
           publish-token-variable: CIRCLECI_DEV_API_TOKEN
           validate: true
           filters:

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -289,6 +289,7 @@ jobs:
                   containerId=$(docker create << parameters.built-image >>)
                   docker cp $containerId:<<parameters.working-directory>>/public/assets public/assets
                   docker rm -v $containerId
+                  rm -rf public/assets/assets
             - save_cache:
                 name: Save Compiled Assets
                 paths:
@@ -304,6 +305,7 @@ jobs:
                   containerId=$(docker create << parameters.built-image >>)
                   docker cp $containerId:<<parameters.working-directory>>/public/packs public/packs
                   docker rm -v $containerId
+                  rm -rf public/packs/packs
             - save_cache:
                 name: Save Compiled Packs
                 paths:

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -261,16 +261,16 @@ jobs:
             - restore_cache:
                 name: Restore Compiled Assets
                 keys:
-                  - v1-asset-cache-{{ .Branch }}
-                  - v1-asset-cache
+                  - v2-asset-cache-{{ .Branch }}
+                  - v2-asset-cache
       - when:
           condition: << parameters.cache-packs >>
           steps:
             - restore_cache:
                 name: Restore Compiled Packs
                 keys:
-                  - v1-pack-cache-{{ .Branch }}
-                  - v1-pack-cache
+                  - v2-pack-cache-{{ .Branch }}
+                  - v2-pack-cache
       - run:
           name: Build the builder image
           command: |
@@ -293,7 +293,7 @@ jobs:
                 name: Save Compiled Assets
                 paths:
                   - public/assets
-                key: v1-asset-cache-{{ .Branch }}-{{ .Revision }}
+                key: v2-asset-cache-{{ .Branch }}-{{ .Revision }}
       - when:
           condition: << parameters.cache-packs >>
           steps:
@@ -308,7 +308,7 @@ jobs:
                 name: Save Compiled Packs
                 paths:
                   - public/packs
-                key: v1-pack-cache-{{ .Branch }}-{{ .Revision }}
+                key: v2-pack-cache-{{ .Branch }}-{{ .Revision }}
       - run:
           name: Log into private registry
           command: |

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -285,8 +285,9 @@ jobs:
             - run:
                 name: Copy Compiled Assets From Built Image
                 command: |
-                  containerId=$(docker create << parameters.built-image >>); \
-                  docker cp $containerId:<<parameters.working-directory>>/public/assets public/assets;
+                  rm -rf public/assets
+                  containerId=$(docker create << parameters.built-image >>)
+                  docker cp $containerId:<<parameters.working-directory>>/public/assets public/assets
                   docker rm -v $containerId
             - save_cache:
                 name: Save Compiled Assets
@@ -299,8 +300,9 @@ jobs:
             - run:
                 name: Copy Compiled Packs From Built Image
                 command: |
-                  containerId=$(docker create << parameters.built-image >>); \
-                  docker cp $containerId:<<parameters.working-directory>>/public/packs public/packs;
+                  rm -rf public/packs
+                  containerId=$(docker create << parameters.built-image >>)
+                  docker cp $containerId:<<parameters.working-directory>>/public/packs public/packs
                   docker rm -v $containerId
             - save_cache:
                 name: Save Compiled Packs


### PR DESCRIPTION
## Summary

- Fix `docker cp` behavior that causes recursive nesting of `public/assets/` (and `public/packs/`) when `cache-assets: true` or `cache-packs: true`

## Root cause

`docker cp CONTAINER:src_dir dest_dir` behaves differently depending on whether `dest_dir` already exists:

- **Does not exist** → creates it with source contents (correct)
- **Already exists** → copies source directory **INTO** destination, creating `dest_dir/basename(src_dir)/` (nested!)

Since `restore_cache` creates `public/assets/` before the build, the subsequent `docker cp` on extraction produces `public/assets/assets/`. `save_cache` persists this, and the next build adds another level. Every build compounds:

```
Build 1: public/assets/          (correct)
Build 2: public/assets/assets/   (one level nested)
Build 3: public/assets/assets/assets/  (two levels)
...
Build 99: 99 levels deep, 128K duplicated files, 1.8 GB uncompressed
```

On atlas-navigator this ballooned the image from 330 MB → 932 MB over ~5 months.

## Fix

`rm -rf public/assets` (and `public/packs`) before `docker cp` so the destination does not exist. The cache restore still serves its purpose — cached assets were already injected into the Docker build context for `assets:precompile`. We just need a clean extraction afterward.

## Impact on framer PR

Once this is merged and published as a new orb version (e.g. `2.2.6`), [brandnewbox/framer#123](https://github.com/brandnewbox/framer/pull/123) should be updated to:

1. **Re-enable `cache-assets: true`** in both `build-and-push-builder` and `build-and-push-production` jobs (the workaround of `cache-assets: false` is no longer needed)
2. **Remove the comment block** explaining the Propshaft workaround
3. **Bump the orb version** from `brandnewbox/drydock@2.2.5` to the new version
4. The other Dockerfile optimizations in that PR (build-essential move, ruby glob fix, .dockerignore, .o/.c stripping) are still valuable and independent of this fix

Ref: brandnewbox/framer#122

🤖 Generated with [Claude Code](https://claude.com/claude-code)